### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,4 @@ updates:
   - package-ecosystem: "gradle" 
     directory: "/" 
     schedule:
-      interval: "weekly"
-    commit-message:
-      include: "release-notes"
+      interval: "daily"


### PR DESCRIPTION
This pull request includes a change to the `dependabot.yml` configuration file. The update frequency for Gradle dependencies has been increased, and the `commit-message` option has been removed.

The key changes are:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L6-R6): The `interval` under `schedule` has been changed from `weekly` to `daily`, indicating that Dependabot will now check for updates to Gradle dependencies on a daily basis instead of weekly. Additionally, the `commit-message` option, which previously included `release-notes`, has been removed.